### PR TITLE
PoC: Hybrid approach for proof generation

### DIFF
--- a/beacon-chain/rpc/prysm/beacon/BUILD.bazel
+++ b/beacon-chain/rpc/prysm/beacon/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//time/slots:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_prysmaticlabs_fastssz//:go_default_library",
     ],
 )
 

--- a/beacon-chain/state/BUILD.bazel
+++ b/beacon-chain/state/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//beacon-chain/state/state-native/custom-types:go_default_library",
+        "//beacon-chain/state/state-native/types:go_default_library",
         "//config/fieldparams:go_default_library",
         "//consensus-types/interfaces:go_default_library",
         "//consensus-types/primitives:go_default_library",

--- a/beacon-chain/state/interfaces.go
+++ b/beacon-chain/state/interfaces.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/OffchainLabs/go-bitfield"
 	customtypes "github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native/custom-types"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native/types"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
@@ -43,6 +44,7 @@ type Prover interface {
 	FinalizedRootProof(ctx context.Context) ([][]byte, error)
 	CurrentSyncCommitteeProof(ctx context.Context) ([][]byte, error)
 	NextSyncCommitteeProof(ctx context.Context) ([][]byte, error)
+	ProofByFieldIndex(ctx context.Context, f types.FieldIndex) ([][]byte, error)
 }
 
 // ReadOnlyBeaconState defines a struct which only has read access to beacon state methods.

--- a/beacon-chain/state/state-native/proofs.go
+++ b/beacon-chain/state/state-native/proofs.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native/types"
+	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/container/trie"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
@@ -39,42 +40,12 @@ func (b *BeaconState) NextSyncCommitteeGeneralizedIndex() (uint64, error) {
 
 // CurrentSyncCommitteeProof from the state's Merkle trie representation.
 func (b *BeaconState) CurrentSyncCommitteeProof(ctx context.Context) ([][]byte, error) {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
-	if b.version == version.Phase0 {
-		return nil, errNotSupported("CurrentSyncCommitteeProof", b.version)
-	}
-
-	// In case the Merkle layers of the trie are not populated, we need
-	// to perform some initialization.
-	if err := b.initializeMerkleLayers(ctx); err != nil {
-		return nil, err
-	}
-	// Our beacon state uses a "dirty" fields pattern which requires us to
-	// recompute branches of the Merkle layers that are marked as dirty.
-	if err := b.recomputeDirtyFields(ctx); err != nil {
-		return nil, err
-	}
-	return trie.ProofFromMerkleLayers(b.merkleLayers, types.CurrentSyncCommittee.RealPosition()), nil
+	return b.ProofByFieldIndex(ctx, types.CurrentSyncCommittee)
 }
 
 // NextSyncCommitteeProof from the state's Merkle trie representation.
 func (b *BeaconState) NextSyncCommitteeProof(ctx context.Context) ([][]byte, error) {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
-	if b.version == version.Phase0 {
-		return nil, errNotSupported("NextSyncCommitteeProof", b.version)
-	}
-
-	if err := b.initializeMerkleLayers(ctx); err != nil {
-		return nil, err
-	}
-	if err := b.recomputeDirtyFields(ctx); err != nil {
-		return nil, err
-	}
-	return trie.ProofFromMerkleLayers(b.merkleLayers, types.NextSyncCommittee.RealPosition()), nil
+	return b.ProofByFieldIndex(ctx, types.NextSyncCommittee)
 }
 
 // FinalizedRootProof crafts a Merkle proof for the finalized root
@@ -83,8 +54,37 @@ func (b *BeaconState) FinalizedRootProof(ctx context.Context) ([][]byte, error) 
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	if b.version == version.Phase0 {
-		return nil, errNotSupported("FinalizedRootProof", b.version)
+	branchProof, err := b.proofByFieldIndex(ctx, types.FinalizedCheckpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// The epoch field of a finalized checkpoint is the neighbor
+	// index of the finalized root field in its Merkle tree representation
+	// of the checkpoint. This neighbor is the first element added to the proof.
+	epochBuf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(epochBuf, uint64(b.finalizedCheckpointVal().Epoch))
+	epochRoot := bytesutil.ToBytes32(epochBuf)
+	proof := make([][]byte, 0)
+	proof = append(proof, epochRoot[:])
+	proof = append(proof, branchProof...)
+	return proof, nil
+}
+
+// ProofByFieldIndex constructs proofs for given field index with lock acquisition.
+func (b *BeaconState) ProofByFieldIndex(ctx context.Context, f types.FieldIndex) ([][]byte, error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	return b.proofByFieldIndex(ctx, f)
+}
+
+// proofByFieldIndex constructs proofs for given field index.
+// Important: it is assumed that beacon state mutex is locked when calling this method.
+func (b *BeaconState) proofByFieldIndex(ctx context.Context, f types.FieldIndex) ([][]byte, error) {
+	err := b.validateFieldIndex(f)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := b.initializeMerkleLayers(ctx); err != nil {
@@ -93,16 +93,40 @@ func (b *BeaconState) FinalizedRootProof(ctx context.Context) ([][]byte, error) 
 	if err := b.recomputeDirtyFields(ctx); err != nil {
 		return nil, err
 	}
-	cpt := b.finalizedCheckpointVal()
-	// The epoch field of a finalized checkpoint is the neighbor
-	// index of the finalized root field in its Merkle tree representation
-	// of the checkpoint. This neighbor is the first element added to the proof.
-	epochBuf := make([]byte, 8)
-	binary.LittleEndian.PutUint64(epochBuf, uint64(cpt.Epoch))
-	epochRoot := bytesutil.ToBytes32(epochBuf)
-	proof := make([][]byte, 0)
-	proof = append(proof, epochRoot[:])
-	branch := trie.ProofFromMerkleLayers(b.merkleLayers, types.FinalizedCheckpoint.RealPosition())
-	proof = append(proof, branch...)
-	return proof, nil
+	return trie.ProofFromMerkleLayers(b.merkleLayers, f.RealPosition()), nil
+}
+
+func (b *BeaconState) validateFieldIndex(f types.FieldIndex) error {
+	switch b.version {
+	case version.Phase0:
+		if f.RealPosition() > params.BeaconConfig().BeaconStateFieldCount-1 {
+			return errNotSupported(f.String(), b.version)
+		}
+	case version.Altair:
+		if f.RealPosition() > params.BeaconConfig().BeaconStateAltairFieldCount-1 {
+			return errNotSupported(f.String(), b.version)
+		}
+	case version.Bellatrix:
+		if f.RealPosition() > params.BeaconConfig().BeaconStateBellatrixFieldCount-1 {
+			return errNotSupported(f.String(), b.version)
+		}
+	case version.Capella:
+		if f.RealPosition() > params.BeaconConfig().BeaconStateCapellaFieldCount-1 {
+			return errNotSupported(f.String(), b.version)
+		}
+	case version.Deneb:
+		if f.RealPosition() > params.BeaconConfig().BeaconStateDenebFieldCount-1 {
+			return errNotSupported(f.String(), b.version)
+		}
+	case version.Electra:
+		if f.RealPosition() > params.BeaconConfig().BeaconStateElectraFieldCount-1 {
+			return errNotSupported(f.String(), b.version)
+		}
+	case version.Fulu:
+		if f.RealPosition() > params.BeaconConfig().BeaconStateFuluFieldCount-1 {
+			return errNotSupported(f.String(), b.version)
+		}
+	}
+
+	return nil
 }

--- a/encoding/ssz/query/BUILD.bazel
+++ b/encoding/ssz/query/BUILD.bazel
@@ -35,15 +35,21 @@ go_test(
     name = "go_default_test",
     srcs = [
         "generalized_index_test.go",
+        "merkle_proof_test.go",
         "path_test.go",
         "query_test.go",
         "tag_parser_test.go",
     ],
     deps = [
         ":go_default_library",
+        "//beacon-chain/state:go_default_library",
+        "//beacon-chain/state/state-native/types:go_default_library",
+        "//consensus-types/primitives:go_default_library",
         "//encoding/ssz/query/testutil:go_default_library",
+        "//proto/prysm/v1alpha1:go_default_library",
         "//proto/ssz_query/testing:go_default_library",
         "//testing/require:go_default_library",
+        "//testing/util:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
     ],
 )

--- a/encoding/ssz/query/container.go
+++ b/encoding/ssz/query/container.go
@@ -18,3 +18,15 @@ type fieldInfo struct {
 	// goFieldName is the name of the field in Go struct.
 	goFieldName string
 }
+
+func (ci *containerInfo) Fields() map[string]*fieldInfo {
+	if ci == nil {
+		return nil
+	}
+
+	return ci.fields
+}
+
+func (fi *fieldInfo) SszInfo() *SszInfo {
+	return fi.sszInfo
+}

--- a/encoding/ssz/query/merkle_proof.go
+++ b/encoding/ssz/query/merkle_proof.go
@@ -19,14 +19,14 @@ func (info *SszInfo) Prove(gindex uint64) (*fastssz.Proof, error) {
 	}
 
 	collector := NewProofCollector()
-	collector.registerRequiredSiblings(gindex)
+	collector.RegisterRequiredSiblings(gindex)
 
 	// info.source is guaranteed to be valid and dereferenced by AnalyzeObject
 	v := reflect.ValueOf(info.source).Elem()
 
-	if _, err := collector.merkleize(info, v, 1); err != nil {
+	if _, err := collector.Merkleize(info, v, 1); err != nil {
 		return nil, err
 	}
 
-	return collector.toProof()
+	return collector.ToProof()
 }

--- a/encoding/ssz/query/merkle_proof_test.go
+++ b/encoding/ssz/query/merkle_proof_test.go
@@ -1,0 +1,126 @@
+package query_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native/types"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/encoding/ssz/query"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"github.com/OffchainLabs/prysm/v7/testing/util"
+)
+
+func setupBeaconState(t testing.TB, numValidators uint64) (state.BeaconState, *ethpb.BeaconState, *query.SszInfo) {
+	st, _ := util.DeterministicGenesisState(t, numValidators)
+	require.NoError(t, st.SetSlot(primitives.Slot(42)))
+
+	pb, ok := st.ToProtoUnsafe().(*ethpb.BeaconState)
+	require.Equal(t, true, ok, "expected Phase0 BeaconState")
+
+	info, err := query.AnalyzeObject(pb)
+	require.NoError(t, err)
+
+	return st, pb, info
+}
+
+func getGIndex(t testing.TB, info *query.SszInfo, pathStr string) uint64 {
+	path, err := query.ParsePath(pathStr)
+	require.NoError(t, err)
+	gindex, err := query.GetGeneralizedIndexFromPath(info, path)
+	require.NoError(t, err)
+	return gindex
+}
+
+func TestBeaconStateProof_Shallow(t *testing.T) {
+	st, _, info := setupBeaconState(t, 64)
+	gindex := getGIndex(t, info, ".validators")
+
+	legacyProof, err := info.Prove(gindex)
+	require.NoError(t, err)
+
+	optProof, err := st.ProofByFieldIndex(t.Context(), types.Validators)
+	require.NoError(t, err)
+
+	require.DeepEqual(t, legacyProof.Hashes, optProof)
+}
+
+func TestBeaconStateProof_Deep(t *testing.T) {
+	st, pb, info := setupBeaconState(t, 64)
+	gindex := getGIndex(t, info, ".validators[0]")
+
+	legacyProof, err := info.Prove(gindex)
+	require.NoError(t, err)
+
+	topProof, err := st.ProofByFieldIndex(t.Context(), types.Validators)
+	require.NoError(t, err)
+
+	ci, err := info.ContainerInfo()
+	require.NoError(t, err)
+
+	fields := ci.Fields()
+	validators := fields["validators"].SszInfo()
+
+	collector := query.NewProofCollector()
+	collector.RegisterRequiredSiblings(1 << 41)
+
+	value := reflect.ValueOf(pb.Validators)
+
+	_, err = collector.Merkleize(validators, value, 1)
+	require.NoError(t, err)
+
+	bottomProof, err := collector.ToProof()
+	require.NoError(t, err)
+
+	combinedProof := append(bottomProof.Hashes, topProof...)
+	require.DeepEqual(t, legacyProof.Hashes, combinedProof)
+}
+
+func BenchmarkBeaconStateProof_Comparison(b *testing.B) {
+	st, pb, info := setupBeaconState(b, 64)
+
+	gindexShallow := getGIndex(b, info, ".validators")
+	gindexDeep := getGIndex(b, info, ".validators[0]")
+
+	ci, _ := info.ContainerInfo()
+	fields := ci.Fields()
+	vInfo := fields["validators"].SszInfo()
+	vVal := reflect.ValueOf(pb.Validators)
+
+	b.Run("Shallow (\".validators\")_Legacy", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = info.Prove(gindexShallow)
+		}
+	})
+
+	b.Run("Shallow (\".validators\")_Optimized", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = st.ProofByFieldIndex(b.Context(), types.Validators)
+		}
+	})
+
+	b.Run("Deep (\".validators[0]\")_Legacy", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = info.Prove(gindexDeep)
+		}
+	})
+
+	b.Run("Deep (\".validators[0]\")_Optimized", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			top, _ := st.ProofByFieldIndex(b.Context(), types.Validators)
+
+			collector := query.NewProofCollector()
+			collector.RegisterRequiredSiblings(1 << 41)
+			_, _ = collector.Merkleize(vInfo, vVal, 1)
+			bottom, _ := collector.ToProof()
+
+			_ = append(bottom.Hashes, top...)
+		}
+	})
+}

--- a/encoding/ssz/query/proof_collector.go
+++ b/encoding/ssz/query/proof_collector.go
@@ -78,9 +78,9 @@ func (pc *ProofCollector) AddTarget(gindex uint64) {
 	}
 }
 
-// toProof converts the collected siblings and leaves into a fastssz.Proof structure.
+// ToProof converts the collected siblings and leaves into a fastssz.Proof structure.
 // Current behavior expects a single target leaf (single proof).
-func (pc *ProofCollector) toProof() (*fastssz.Proof, error) {
+func (pc *ProofCollector) ToProof() (*fastssz.Proof, error) {
 	pc.Lock()
 	defer pc.Unlock()
 
@@ -122,10 +122,10 @@ func (pc *ProofCollector) toProof() (*fastssz.Proof, error) {
 	return proof, nil
 }
 
-// registerRequiredSiblings computes all sibling generalized indices along the path
+// RegisterRequiredSiblings computes all sibling generalized indices along the path
 // from the given gindex up to the root. These are the nodes whose hashes
 // are needed to construct a merkle proof.
-func (pc *ProofCollector) registerRequiredSiblings(gindex uint64) {
+func (pc *ProofCollector) RegisterRequiredSiblings(gindex uint64) {
 	pc.Reset()
 	pc.AddTarget(gindex)
 }
@@ -151,14 +151,14 @@ func putLittleEndian(dst []byte, val uint64, size int) {
 
 // Merkleizers and proof collection methods
 
-// merkleize recursively traverses an SSZ info and computes the Merkle root of the subtree.
+// Merkleize recursively traverses an SSZ info and computes the Merkle root of the subtree.
 //
 // Proof collection:
 //   - During traversal it calls collectLeaf/collectSibling with the SSZ generalized indices (gindices)
 //     of visited nodes.
 //   - The collector only stores hashes for gindices that were pre-registered via AddTarget
 //     (requiredLeaves/requiredSiblings). This makes the traversal multiproof-ready: you can register
-//     multiple targets before calling merkleize.
+//     multiple targets before calling Merkleize.
 //
 // SSZ types handled: basic types, containers, lists, vectors, bitlists, and bitvectors.
 //
@@ -170,7 +170,7 @@ func putLittleEndian(dst []byte, val uint64, size int) {
 // Returns:
 // - [32]byte: Merkle root of the current subtree.
 // - error: any error encountered during traversal/merkleization.
-func (pc *ProofCollector) merkleize(info *SszInfo, v reflect.Value, currentGindex uint64) ([32]byte, error) {
+func (pc *ProofCollector) Merkleize(info *SszInfo, v reflect.Value, currentGindex uint64) ([32]byte, error) {
 	if info.sszType.isBasic() {
 		return pc.merkleizeBasicType(info.sszType, v, currentGindex)
 	}
@@ -266,7 +266,7 @@ func (pc *ProofCollector) merkleizeContainer(info *SszInfo, v reflect.Value, cur
 		// Field i's gindex: shift currentGindex left by depth, then OR with field index
 		fieldGindex := currentGindex<<depth + uint64(i)
 
-		htr, err := pc.merkleize(fieldInfo.sszInfo, fieldVal, fieldGindex)
+		htr, err := pc.Merkleize(fieldInfo.sszInfo, fieldVal, fieldGindex)
 		if err != nil {
 			return [32]byte{}, fmt.Errorf("field %s: %w", name, err)
 		}
@@ -333,7 +333,7 @@ func (pc *ProofCollector) merkleizeVectorBody(elemInfo *SszInfo, v reflect.Value
 				}
 
 				elemGindex := subtreeRootGindex<<depth + uint64(idx)
-				htr, err := pc.merkleize(elemInfo, v.Index(idx), elemGindex)
+				htr, err := pc.Merkleize(elemInfo, v.Index(idx), elemGindex)
 				if err != nil {
 					stopOnce.Do(func() { close(stopCh) })
 					select {


### PR DESCRIPTION
Hybrid approach that appends hashes from "top" and "bottom". Here's benchmark:

```
goos: darwin
goarch: arm64
pkg: github.com/OffchainLabs/prysm/v7/encoding/ssz/query
cpu: Apple M4 Pro
BenchmarkBeaconStateProof_Comparison/Shallow_(".validators")_Legacy-12                   34      29485343 ns/op     8073892 B/op       82783 allocs/op
BenchmarkBeaconStateProof_Comparison/Shallow_(".validators")_Optimized-12          10684382           111.8 ns/op         360 B/op           4 allocs/op
BenchmarkBeaconStateProof_Comparison/Deep_(".validators[0]")_Legacy-12                   34      31023547 ns/op     8078903 B/op       82828 allocs/op
BenchmarkBeaconStateProof_Comparison/Deep_(".validators[0]")_Optimized-12             16837         71257 ns/op       61785 B/op         607 allocs/op
```